### PR TITLE
Use Buffer.alloc if present

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var hasFullSupport = (function () {
       return false
     }
 
-    var buf = new Buffer(4)
+    var buf = Buffer.alloc ? Buffer.alloc(4) : new Buffer(4)
 
     buf.fill('ab', 'ucs2')
 


### PR DESCRIPTION
Ironically I've been using `buffer-alloc` to avoid the future `new Buffer` deprecation warning. `buffer-alloc` depends on this module that uses `new Buffer` in the setup making it hard to escape the deprecation :laughing: 